### PR TITLE
Tryout editing

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -212,6 +212,7 @@ enum TeamInviteStatus {
 model Tryout {
   id                String   @id
   name              String
+  acronym 			String
   staff_channel_id  String
   player_channel_id String
   embed_channel_id  String?

--- a/src/commands/tryout.ts
+++ b/src/commands/tryout.ts
@@ -1837,7 +1837,7 @@ export class TryoutCommand extends Subcommand {
 			ephemeral: true,
 		});
 
-		const acronym = interaction.options.getString("value", true);
+		const acronym = interaction.options.getString("value", true).toUpperCase();
 
 		const user = await db.user.findFirst({
 			where: {

--- a/src/commands/tryout.ts
+++ b/src/commands/tryout.ts
@@ -1743,9 +1743,7 @@ export class TryoutCommand extends Subcommand {
 	public async chatInputEditName(
 		interaction: Subcommand.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply({
-			ephemeral: true,
-		});
+		await interaction.deferReply();
 
 		const name = interaction.options.getString("value", true);
 
@@ -1843,9 +1841,7 @@ export class TryoutCommand extends Subcommand {
 	public async chatInputEditAcronym(
 		interaction: Subcommand.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply({
-			ephemeral: true,
-		});
+		await interaction.deferReply();
 
 		const acronym = interaction.options.getString("value", true).toUpperCase();
 
@@ -1943,9 +1939,7 @@ export class TryoutCommand extends Subcommand {
 	public async chatInputEditStartDate(
 		interaction: Subcommand.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply({
-			ephemeral: true,
-		});
+		await interaction.deferReply();
 
 		const date = DateTime.fromFormat(
 			interaction.options.getString("value", true),
@@ -2084,9 +2078,7 @@ export class TryoutCommand extends Subcommand {
 	public async chatInputEditEndDate(
 		interaction: Subcommand.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply({
-			ephemeral: true,
-		});
+		await interaction.deferReply();
 
 		const date = DateTime.fromFormat(
 			interaction.options.getString("value", true),
@@ -2225,9 +2217,7 @@ export class TryoutCommand extends Subcommand {
 	public async chatInputEditStaffChannel(
 		interaction: Subcommand.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply({
-			ephemeral: true,
-		});
+		await interaction.deferReply();
 
 		let channel = interaction.options.getChannel("channel");
 		const deletePrevious = interaction.options.getBoolean("delete-previous");
@@ -2411,9 +2401,7 @@ export class TryoutCommand extends Subcommand {
 	public async chatInputEditPlayerChannel(
 		interaction: Subcommand.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply({
-			ephemeral: true,
-		});
+		await interaction.deferReply();
 
 		let channel = interaction.options.getChannel("channel");
 		const deletePrevious = interaction.options.getBoolean("delete-previous");

--- a/src/commands/tryout.ts
+++ b/src/commands/tryout.ts
@@ -2229,7 +2229,7 @@ export class TryoutCommand extends Subcommand {
 			ephemeral: true,
 		});
 
-		const channel = interaction.options.getChannel("channel", true);
+		let channel = interaction.options.getChannel("channel");
 
 		const user = await db.user.findFirst({
 			where: {
@@ -2286,35 +2286,75 @@ export class TryoutCommand extends Subcommand {
 			return;
 		}
 
-		const overlappingTryout = await db.tryout.findFirst({
-			where: {
-				OR: [
-					{
-						staff_channel_id: channel.id,
+		if (channel) {
+			const overlappingTryout = await db.tryout.findFirst({
+				where: {
+					OR: [
+						{
+							staff_channel_id: channel.id,
+						},
+						{
+							player_channel_id: channel.id,
+						},
+					],
+					NOT: {
+						id: tryout.id,
 					},
-					{
-						player_channel_id: channel.id,
-					},
-				],
-				NOT: {
-					id: tryout.id,
 				},
-			},
-		});
-
-		if (overlappingTryout) {
-			await interaction.editReply({
-				embeds: [
-					new EmbedBuilder()
-						.setColor("Red")
-						.setTitle("Channel already in use!")
-						.setDescription(
-							"The channel you specified is already in use by another tryout.",
-						),
-				],
 			});
 
-			return;
+			if (overlappingTryout) {
+				await interaction.editReply({
+					embeds: [
+						new EmbedBuilder()
+							.setColor("Red")
+							.setTitle("Channel already in use!")
+							.setDescription(
+								"The channel you specified is already in use by another tryout.",
+							),
+					],
+				});
+
+				return;
+			}
+		}
+
+		if (!channel) {
+			try {
+				channel = (await interaction.guild!.channels.create({
+					name: `${tryout.acronym}-staff`,
+					type: ChannelType.GuildText,
+					permissionOverwrites: [
+						{
+							id: interaction.guild!.roles.everyone.id,
+							deny: [PermissionFlagsBits.ViewChannel],
+						},
+						{
+							id: tryout.admin_role_id,
+							allow: [PermissionFlagsBits.ViewChannel],
+						},
+						{
+							id: tryout.referee_role_id,
+							allow: [PermissionFlagsBits.ViewChannel],
+						},
+					],
+				})) as GuildTextBasedChannel;
+			} catch (error) {
+				this.container.logger.error(error);
+
+				await interaction.editReply({
+					embeds: [
+						new EmbedBuilder()
+							.setColor("Red")
+							.setTitle("Error")
+							.setDescription(
+								"An error occurred while creating the staff channel.",
+							),
+					],
+				});
+
+				return;
+			}
 		}
 
 		try {
@@ -2358,7 +2398,7 @@ export class TryoutCommand extends Subcommand {
 			ephemeral: true,
 		});
 
-		const channel = interaction.options.getChannel("channel", true);
+		let channel = interaction.options.getChannel("channel");
 
 		const user = await db.user.findFirst({
 			where: {
@@ -2415,35 +2455,79 @@ export class TryoutCommand extends Subcommand {
 			return;
 		}
 
-		const overlappingTryout = await db.tryout.findFirst({
-			where: {
-				OR: [
-					{
-						staff_channel_id: channel.id,
+		if (channel) {
+			const overlappingTryout = await db.tryout.findFirst({
+				where: {
+					OR: [
+						{
+							staff_channel_id: channel.id,
+						},
+						{
+							player_channel_id: channel.id,
+						},
+					],
+					NOT: {
+						id: tryout.id,
 					},
-					{
-						player_channel_id: channel.id,
-					},
-				],
-				NOT: {
-					id: tryout.id,
 				},
-			},
-		});
-
-		if (overlappingTryout) {
-			await interaction.editReply({
-				embeds: [
-					new EmbedBuilder()
-						.setColor("Red")
-						.setTitle("Channel already in use!")
-						.setDescription(
-							"The channel you specified is already in use by another tryout.",
-						),
-				],
 			});
 
-			return;
+			if (overlappingTryout) {
+				await interaction.editReply({
+					embeds: [
+						new EmbedBuilder()
+							.setColor("Red")
+							.setTitle("Channel already in use!")
+							.setDescription(
+								"The channel you specified is already in use by another tryout.",
+							),
+					],
+				});
+
+				return;
+			}
+		}
+
+		if (!channel) {
+			try {
+				channel = (await interaction.guild!.channels.create({
+					name: `${tryout.acronym}-players`,
+					type: ChannelType.GuildText,
+					permissionOverwrites: [
+						{
+							id: interaction.guild!.roles.everyone.id,
+							deny: [PermissionFlagsBits.ViewChannel],
+						},
+						{
+							id: tryout.player_role_id,
+							allow: [PermissionFlagsBits.ViewChannel],
+						},
+						{
+							id: tryout.admin_role_id,
+							allow: [PermissionFlagsBits.ViewChannel],
+						},
+						{
+							id: tryout.referee_role_id,
+							allow: [PermissionFlagsBits.ViewChannel],
+						},
+					],
+				})) as GuildTextBasedChannel;
+			} catch (error) {
+				this.container.logger.error(error);
+
+				await interaction.editReply({
+					embeds: [
+						new EmbedBuilder()
+							.setColor("Red")
+							.setTitle("Error")
+							.setDescription(
+								"An error occurred while creating the player channel.",
+							),
+					],
+				});
+
+				return;
+			}
 		}
 
 		try {

--- a/src/commands/tryout.ts
+++ b/src/commands/tryout.ts
@@ -2033,6 +2033,9 @@ export class TryoutCommand extends Subcommand {
 						.setDescription(
 							`The tryout start date has been updated from \`${DateTime.fromJSDate(
 								tryout.start_date,
+								{
+									zone: "utc",
+								},
 							).toRFC2822()}\` to \`${date.toRFC2822()}\`.`,
 						),
 				],
@@ -2156,6 +2159,9 @@ export class TryoutCommand extends Subcommand {
 						.setDescription(
 							`The tryout end date has been updated from \`${DateTime.fromJSDate(
 								tryout.end_date,
+								{
+									zone: "utc",
+								},
 							).toRFC2822()}\` to \`${date.toRFC2822()}\`.`,
 						),
 				],

--- a/src/commands/tryout.ts
+++ b/src/commands/tryout.ts
@@ -2230,6 +2230,7 @@ export class TryoutCommand extends Subcommand {
 		});
 
 		let channel = interaction.options.getChannel("channel");
+		const deletePrevious = interaction.options.getBoolean("delete-previous");
 
 		const user = await db.user.findFirst({
 			where: {
@@ -2357,6 +2358,20 @@ export class TryoutCommand extends Subcommand {
 			}
 		}
 
+		if (deletePrevious) {
+			const previousChannel = await interaction.guild?.channels.fetch(
+				tryout.staff_channel_id,
+			);
+
+			if (previousChannel) {
+				try {
+					await previousChannel.delete();
+				} catch (error) {
+					this.container.logger.error(error);
+				}
+			}
+		}
+
 		try {
 			await db.tryout.update({
 				where: {
@@ -2372,7 +2387,9 @@ export class TryoutCommand extends Subcommand {
 					new EmbedBuilder()
 						.setColor("Green")
 						.setTitle("Success")
-						.setDescription("The staff channel has been updated."),
+						.setDescription(
+							`The staff channel has been updated to <#${channel.id}>.`,
+						),
 				],
 			});
 		} catch (error) {
@@ -2399,6 +2416,7 @@ export class TryoutCommand extends Subcommand {
 		});
 
 		let channel = interaction.options.getChannel("channel");
+		const deletePrevious = interaction.options.getBoolean("delete-previous");
 
 		const user = await db.user.findFirst({
 			where: {
@@ -2530,6 +2548,20 @@ export class TryoutCommand extends Subcommand {
 			}
 		}
 
+		if (deletePrevious) {
+			const previousChannel = await interaction.guild?.channels.fetch(
+				tryout.player_channel_id,
+			);
+
+			if (previousChannel) {
+				try {
+					await previousChannel.delete();
+				} catch (error) {
+					this.container.logger.error(error);
+				}
+			}
+		}
+
 		try {
 			await db.tryout.update({
 				where: {
@@ -2545,7 +2577,9 @@ export class TryoutCommand extends Subcommand {
 					new EmbedBuilder()
 						.setColor("Green")
 						.setTitle("Success")
-						.setDescription("The player channel has been updated."),
+						.setDescription(
+							`The player channel has been updated to <#${channel.id}>.`,
+						),
 				],
 			});
 		} catch (error) {

--- a/src/commands/tryout.ts
+++ b/src/commands/tryout.ts
@@ -1833,7 +1833,101 @@ export class TryoutCommand extends Subcommand {
 	public async chatInputEditAcronym(
 		interaction: Subcommand.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply();
+		await interaction.deferReply({
+			ephemeral: true,
+		});
+
+		const acronym = interaction.options.getString("value", true);
+
+		const user = await db.user.findFirst({
+			where: {
+				discord_id: interaction.user.id,
+			},
+		});
+
+		if (!user) {
+			await interaction.editReply({
+				embeds: [NoAccountEmbed],
+			});
+
+			return;
+		}
+
+		const tryout = await db.tryout.findFirst({
+			where: {
+				OR: [
+					{
+						staff_channel_id: interaction.channelId,
+					},
+					{
+						player_channel_id: interaction.channelId,
+					},
+				],
+			},
+		});
+
+		if (!tryout) {
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Red")
+						.setTitle("Invalid channel!")
+						.setDescription(
+							"This command can only be used in a tryout channel.",
+						),
+				],
+			});
+
+			return;
+		}
+
+		if (!isUserTryoutAdmin(interaction, tryout)) {
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Red")
+						.setTitle("Invalid permissions!")
+						.setDescription("You don't have permission to do this."),
+				],
+			});
+
+			return;
+		}
+
+		try {
+			await db.tryout.update({
+				where: {
+					id: tryout.id,
+				},
+				data: {
+					acronym,
+				},
+			});
+
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Green")
+						.setTitle("Success")
+						.setDescription(
+							`The tryout acronym has been updated from \`${tryout.acronym}\` to \`${acronym}\`.`,
+						),
+				],
+			});
+		} catch (error) {
+			this.container.logger.error(error);
+
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Red")
+						.setTitle("Error")
+						.setDescription(
+							"An error occurred while updating the tryout acronym. Please try again later.",
+						),
+				],
+			});
+		}
 	}
 
 	public async chatInputEditStartDate(

--- a/src/commands/tryout.ts
+++ b/src/commands/tryout.ts
@@ -2348,7 +2348,7 @@ export class TryoutCommand extends Subcommand {
 			}
 		}
 
-		if (deletePrevious) {
+		if (deletePrevious && tryout.staff_channel_id !== channel.id) {
 			const previousChannel = await interaction.guild?.channels.fetch(
 				tryout.staff_channel_id,
 			);
@@ -2536,7 +2536,7 @@ export class TryoutCommand extends Subcommand {
 			}
 		}
 
-		if (deletePrevious) {
+		if (deletePrevious && tryout.player_channel_id !== channel.id) {
 			const previousChannel = await interaction.guild?.channels.fetch(
 				tryout.player_channel_id,
 			);

--- a/src/commands/tryout.ts
+++ b/src/commands/tryout.ts
@@ -70,6 +70,58 @@ import { v2 } from "osu-api-extended";
 				},
 			],
 		},
+		{
+			name: "edit",
+			type: "group",
+			entries: [
+				{
+					name: "name",
+					chatInputRun: "chatInputEditName",
+				},
+				{
+					name: "acronym",
+					chatInputRun: "chatInputEditAcronym",
+				},
+				{
+					name: "start-date",
+					chatInputRun: "chatInputEditStartDate",
+				},
+				{
+					name: "end-date",
+					chatInputRun: "chatInputEditEndDate",
+				},
+				{
+					name: "staff-channel",
+					chatInputRun: "chatInputEditStaffChannel",
+					preconditions: ["ServerAdminOnly"],
+				},
+				{
+					name: "player-channel",
+					chatInputRun: "chatInputEditPlayerChannel",
+					preconditions: ["ServerAdminOnly"],
+				},
+				{
+					name: "player-role",
+					chatInputRun: "chatInputEditPlayerRole",
+					preconditions: ["ServerAdminOnly"],
+				},
+				{
+					name: "management-role",
+					chatInputRun: "chatInputEditManagementRole",
+					preconditions: ["ServerAdminOnly"],
+				},
+				{
+					name: "referee-role",
+					chatInputRun: "chatInputEditRefereeRole",
+					preconditions: ["ServerAdminOnly"],
+				},
+				{
+					name: "allow-staff",
+					chatInputRun: "chatInputEditAllowStaff",
+					preconditions: ["ServerAdminOnly"],
+				},
+			],
+		},
 	],
 })
 export class TryoutCommand extends Subcommand {
@@ -308,6 +360,169 @@ export class TryoutCommand extends Subcommand {
 										)
 										.setRequired(true)
 										.addChannelTypes(ChannelType.GuildText),
+								),
+						),
+				)
+				.addSubcommandGroup((builder) =>
+					builder
+						.setName("edit")
+						.setDescription("Commands for editing tryout data.")
+						.addSubcommand((builder) =>
+							builder
+								.setName("name")
+								.setDescription("Edit the tryout name.")
+								.addStringOption((option) =>
+									option
+										.setName("value")
+										.setDescription("The new tryout name.")
+										.setRequired(true),
+								),
+						)
+						.addSubcommand((builder) =>
+							builder
+								.setName("acronym")
+								.setDescription("Edit the tryout acronym.")
+								.addStringOption((option) =>
+									option
+										.setName("value")
+										.setDescription("The new tryout acronym.")
+										.setRequired(true),
+								),
+						)
+						.addSubcommand((builder) =>
+							builder
+								.setName("start-date")
+								.setDescription("Edit the tryout start date.")
+								.addStringOption((option) =>
+									option
+										.setName("value")
+										.setDescription(
+											"The new tryout start date. (Format: YYYY-MM-DD HH:MM)",
+										)
+										.setRequired(true),
+								),
+						)
+						.addSubcommand((builder) =>
+							builder
+								.setName("end-date")
+								.setDescription("Edit the tryout end date.")
+								.addStringOption((option) =>
+									option
+										.setName("value")
+										.setDescription(
+											"The new tryout end date. (Format: YYYY-MM-DD HH:MM)",
+										)
+										.setRequired(true),
+								),
+						)
+						.addSubcommand((builder) =>
+							builder
+								.setName("staff-channel")
+								.setDescription("Edit the tryout staff channel.")
+								.addChannelOption((option) =>
+									option
+										.setName("channel")
+										.setDescription(
+											"The new tryout staff channel. (Default: New Channel)",
+										)
+										.addChannelTypes(ChannelType.GuildText),
+								)
+								.addBooleanOption((option) =>
+									option
+										.setName("delete-previous")
+										.setDescription(
+											"Whether or not to delete the previous staff channel. (Default: false)",
+										),
+								),
+						)
+						.addSubcommand((builder) =>
+							builder
+								.setName("player-channel")
+								.setDescription("Edit the tryout player channel.")
+								.addChannelOption((option) =>
+									option
+										.setName("channel")
+										.setDescription(
+											"The new tryout player channel. (Default: New Channel)",
+										)
+										.addChannelTypes(ChannelType.GuildText),
+								)
+								.addBooleanOption((option) =>
+									option
+										.setName("delete-previous")
+										.setDescription(
+											"Whether or not to delete the previous player channel. (Default: false)",
+										),
+								),
+						)
+						.addSubcommand((builder) =>
+							builder
+								.setName("player-role")
+								.setDescription("Edit the tryout player role.")
+								.addRoleOption((option) =>
+									option
+										.setName("role")
+										.setDescription(
+											"The new tryout player role. (Default: New Role)",
+										),
+								)
+								.addBooleanOption((option) =>
+									option
+										.setName("delete-previous")
+										.setDescription(
+											"Whether or not to delete the previous player role. (Default: false)",
+										),
+								),
+						)
+						.addSubcommand((builder) =>
+							builder
+								.setName("management-role")
+								.setDescription("Edit the tryout management role.")
+								.addRoleOption((option) =>
+									option
+										.setName("role")
+										.setDescription(
+											"The new tryout management role. (Default: New Role)",
+										),
+								)
+								.addBooleanOption((option) =>
+									option
+										.setName("delete-previous")
+										.setDescription(
+											"Whether or not to delete the previous management role. (Default: false)",
+										),
+								),
+						)
+						.addSubcommand((builder) =>
+							builder
+								.setName("referee-role")
+								.setDescription("Edit the tryout referee role.")
+								.addRoleOption((option) =>
+									option
+										.setName("role")
+										.setDescription(
+											"The new tryout referee role. (Default: New Role)",
+										),
+								)
+								.addBooleanOption((option) =>
+									option
+										.setName("delete-previous")
+										.setDescription(
+											"Whether or not to delete the previous referee role. (Default: false)",
+										),
+								),
+						)
+						.addSubcommand((builder) =>
+							builder
+								.setName("allow-staff")
+								.setDescription("Edit whether or not staff can join.")
+								.addBooleanOption((option) =>
+									option
+										.setName("value")
+										.setDescription(
+											"Whether or not staff members can join the tryout.",
+										)
+										.setRequired(true),
 								),
 						),
 				),
@@ -1512,5 +1727,65 @@ export class TryoutCommand extends Subcommand {
 
 			return;
 		}
+	}
+
+	public async chatInputEditName(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply();
+	}
+
+	public async chatInputEditAcronym(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply();
+	}
+
+	public async chatInputEditStartDate(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply();
+	}
+
+	public async chatInputEditEndDate(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply();
+	}
+
+	public async chatInputEditStaffChannel(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply();
+	}
+
+	public async chatInputEditPlayerChannel(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply();
+	}
+
+	public async chatInputEditPlayerRole(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply();
+	}
+
+	public async chatInputEditManagementRole(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply();
+	}
+
+	public async chatInputEditRefereeRole(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply();
+	}
+
+	public async chatInputEditAllowStaff(
+		interaction: Subcommand.ChatInputCommandInteraction,
+	) {
+		await interaction.deferReply();
 	}
 }

--- a/src/commands/tryout.ts
+++ b/src/commands/tryout.ts
@@ -729,6 +729,7 @@ export class TryoutCommand extends Subcommand {
 				data: {
 					id,
 					name,
+					acronym,
 					server_id: interaction.guildId!,
 					embed_channel_id: embedChannel?.id,
 					embed_message_id: embedMessage?.id,

--- a/src/commands/tryout.ts
+++ b/src/commands/tryout.ts
@@ -2056,7 +2056,124 @@ export class TryoutCommand extends Subcommand {
 	public async chatInputEditEndDate(
 		interaction: Subcommand.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply();
+		await interaction.deferReply({
+			ephemeral: true,
+		});
+
+		const date = DateTime.fromFormat(
+			interaction.options.getString("value", true),
+			"yyyy-MM-dd HH:mm",
+			{
+				zone: "utc",
+			},
+		);
+
+		const user = await db.user.findFirst({
+			where: {
+				discord_id: interaction.user.id,
+			},
+		});
+
+		if (!user) {
+			await interaction.editReply({
+				embeds: [NoAccountEmbed],
+			});
+
+			return;
+		}
+
+		const tryout = await db.tryout.findFirst({
+			where: {
+				OR: [
+					{
+						staff_channel_id: interaction.channelId,
+					},
+					{
+						player_channel_id: interaction.channelId,
+					},
+				],
+			},
+		});
+
+		if (!tryout) {
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Red")
+						.setTitle("Invalid channel!")
+						.setDescription(
+							"This command can only be used in a tryout channel.",
+						),
+				],
+			});
+
+			return;
+		}
+
+		if (!isUserTryoutAdmin(interaction, tryout)) {
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Red")
+						.setTitle("Invalid permissions!")
+						.setDescription("You don't have permission to do this."),
+				],
+			});
+
+			return;
+		}
+
+		if (!date.isValid) {
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Red")
+						.setTitle("Invalid date!")
+						.setDescription(
+							"The date you specified is invalid. Please use the format `yyyy-MM-dd HH:mm`.",
+						),
+				],
+			});
+
+			return;
+		}
+
+		try {
+			await db.tryout.update({
+				where: {
+					id: tryout.id,
+				},
+				data: {
+					end_date: date.toJSDate(),
+				},
+			});
+
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Green")
+						.setTitle("Success")
+						.setDescription(
+							`The tryout end date has been updated from \`${DateTime.fromJSDate(
+								tryout.end_date,
+							).toRFC2822()}\` to \`${date.toRFC2822()}\`.`,
+						),
+				],
+			});
+		} catch (error) {
+			this.container.logger.error(error);
+
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Red")
+						.setTitle("Error")
+						.setDescription(
+							"An error occurred while updating the tryout end date. Please try again later.",
+						),
+				],
+			});
+		}
 	}
 
 	public async chatInputEditStaffChannel(

--- a/src/commands/tryout.ts
+++ b/src/commands/tryout.ts
@@ -1732,7 +1732,101 @@ export class TryoutCommand extends Subcommand {
 	public async chatInputEditName(
 		interaction: Subcommand.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply();
+		await interaction.deferReply({
+			ephemeral: true,
+		});
+
+		const name = interaction.options.getString("value", true);
+
+		const user = await db.user.findFirst({
+			where: {
+				discord_id: interaction.user.id,
+			},
+		});
+
+		if (!user) {
+			await interaction.editReply({
+				embeds: [NoAccountEmbed],
+			});
+
+			return;
+		}
+
+		const tryout = await db.tryout.findFirst({
+			where: {
+				OR: [
+					{
+						staff_channel_id: interaction.channelId,
+					},
+					{
+						player_channel_id: interaction.channelId,
+					},
+				],
+			},
+		});
+
+		if (!tryout) {
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Red")
+						.setTitle("Invalid channel!")
+						.setDescription(
+							"This command can only be used in a tryout channel.",
+						),
+				],
+			});
+
+			return;
+		}
+
+		if (!isUserTryoutAdmin(interaction, tryout)) {
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Red")
+						.setTitle("Invalid permissions!")
+						.setDescription("You don't have permission to do this."),
+				],
+			});
+
+			return;
+		}
+
+		try {
+			await db.tryout.update({
+				where: {
+					id: tryout.id,
+				},
+				data: {
+					name,
+				},
+			});
+
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Green")
+						.setTitle("Success")
+						.setDescription(
+							`The tryout name has been updated from \`${tryout.name}\` to \`${name}\`.`,
+						),
+				],
+			});
+		} catch (error) {
+			this.container.logger.error(error);
+
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Red")
+						.setTitle("Error")
+						.setDescription(
+							"An error occurred while updating the tryout name. Please try again later.",
+						),
+				],
+			});
+		}
 	}
 
 	public async chatInputEditAcronym(

--- a/src/commands/tryout.ts
+++ b/src/commands/tryout.ts
@@ -418,7 +418,9 @@ export class TryoutCommand extends Subcommand {
 						.addSubcommand((builder) =>
 							builder
 								.setName("staff-channel")
-								.setDescription("Edit the tryout staff channel.")
+								.setDescription(
+									"Edit the tryout staff channel. (Channel permissions are not updated)",
+								)
 								.addChannelOption((option) =>
 									option
 										.setName("channel")
@@ -438,7 +440,9 @@ export class TryoutCommand extends Subcommand {
 						.addSubcommand((builder) =>
 							builder
 								.setName("player-channel")
-								.setDescription("Edit the tryout player channel.")
+								.setDescription(
+									"Edit the tryout player channel. (Channel permissions are not updated)",
+								)
 								.addChannelOption((option) =>
 									option
 										.setName("channel")
@@ -458,7 +462,9 @@ export class TryoutCommand extends Subcommand {
 						.addSubcommand((builder) =>
 							builder
 								.setName("player-role")
-								.setDescription("Edit the tryout player role.")
+								.setDescription(
+									"Edit the tryout player role. (Channel permissions are not updated)",
+								)
 								.addRoleOption((option) =>
 									option
 										.setName("role")
@@ -477,7 +483,9 @@ export class TryoutCommand extends Subcommand {
 						.addSubcommand((builder) =>
 							builder
 								.setName("management-role")
-								.setDescription("Edit the tryout management role.")
+								.setDescription(
+									"Edit the tryout management role. (Channel permissions are not updated)",
+								)
 								.addRoleOption((option) =>
 									option
 										.setName("role")
@@ -496,7 +504,9 @@ export class TryoutCommand extends Subcommand {
 						.addSubcommand((builder) =>
 							builder
 								.setName("referee-role")
-								.setDescription("Edit the tryout referee role.")
+								.setDescription(
+									"Edit the tryout referee role. (Channel permissions are not updated)",
+								)
 								.addRoleOption((option) =>
 									option
 										.setName("role")

--- a/src/commands/tryout.ts
+++ b/src/commands/tryout.ts
@@ -2354,7 +2354,130 @@ export class TryoutCommand extends Subcommand {
 	public async chatInputEditPlayerChannel(
 		interaction: Subcommand.ChatInputCommandInteraction,
 	) {
-		await interaction.deferReply();
+		await interaction.deferReply({
+			ephemeral: true,
+		});
+
+		const channel = interaction.options.getChannel("channel", true);
+
+		const user = await db.user.findFirst({
+			where: {
+				discord_id: interaction.user.id,
+			},
+		});
+
+		if (!user) {
+			await interaction.editReply({
+				embeds: [NoAccountEmbed],
+			});
+
+			return;
+		}
+
+		const tryout = await db.tryout.findFirst({
+			where: {
+				OR: [
+					{
+						staff_channel_id: interaction.channelId,
+					},
+					{
+						player_channel_id: interaction.channelId,
+					},
+				],
+			},
+		});
+
+		if (!tryout) {
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Red")
+						.setTitle("Invalid channel!")
+						.setDescription(
+							"This command can only be used in a tryout channel.",
+						),
+				],
+			});
+
+			return;
+		}
+
+		if (!isUserTryoutAdmin(interaction, tryout)) {
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Red")
+						.setTitle("Invalid permissions!")
+						.setDescription("You don't have permission to do this."),
+				],
+			});
+
+			return;
+		}
+
+		const overlappingTryout = await db.tryout.findFirst({
+			where: {
+				OR: [
+					{
+						staff_channel_id: channel.id,
+					},
+					{
+						player_channel_id: channel.id,
+					},
+				],
+				NOT: {
+					id: tryout.id,
+				},
+			},
+		});
+
+		if (overlappingTryout) {
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Red")
+						.setTitle("Channel already in use!")
+						.setDescription(
+							"The channel you specified is already in use by another tryout.",
+						),
+				],
+			});
+
+			return;
+		}
+
+		try {
+			await db.tryout.update({
+				where: {
+					id: tryout.id,
+				},
+				data: {
+					player_channel_id: channel.id,
+				},
+			});
+
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Green")
+						.setTitle("Success")
+						.setDescription("The player channel has been updated."),
+				],
+			});
+		} catch (error) {
+			this.container.logger.error(error);
+
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Red")
+						.setTitle("Error")
+						.setDescription(
+							"An error occurred while updating the player channel.",
+						),
+				],
+			});
+		}
 	}
 
 	public async chatInputEditPlayerRole(

--- a/src/commands/tryout.ts
+++ b/src/commands/tryout.ts
@@ -2015,6 +2015,21 @@ export class TryoutCommand extends Subcommand {
 			return;
 		}
 
+		if (tryout.end_date < date.toJSDate()) {
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Red")
+						.setTitle("Invalid date!")
+						.setDescription(
+							"The date you specified is after the tryout end date.",
+						),
+				],
+			});
+
+			return;
+		}
+
 		try {
 			await db.tryout.update({
 				where: {
@@ -2134,6 +2149,21 @@ export class TryoutCommand extends Subcommand {
 						.setTitle("Invalid date!")
 						.setDescription(
 							"The date you specified is invalid. Please use the format `yyyy-MM-dd HH:mm`.",
+						),
+				],
+			});
+
+			return;
+		}
+
+		if (tryout.start_date > date.toJSDate()) {
+			await interaction.editReply({
+				embeds: [
+					new EmbedBuilder()
+						.setColor("Red")
+						.setTitle("Invalid date!")
+						.setDescription(
+							"The date you specified is before the tryout start date.",
 						),
 				],
 			});


### PR DESCRIPTION
## New features
Editing commands for the following parameters:
- Name (f43c6766677d3d602a7d6813713c2a417d371c9e)
- Acronym (c5041ff87e7123cbf4325362d1ffc38ebdb6bc53)
- Start date (a9161f68741d4b0a6f7923bc96f78c152b752441)
- End date (5f23459a65cafd4f806046b169be098c35f73124)
- Staff and player channels (closes #21) (16e38b8d3bc3c3e2dee61f20afcbd68b2cab9630 and 2d6a5aa4332c383d9ad83cf7edcce8d27a875c91)
- Player, referee and management roles (8b3d3046ca1eaea8b45738fea62741dd7f8cadfa)
- Allow staff (f39cdb78884f5ad3ff222e7cad33310273d9399f)

closes #30 